### PR TITLE
fix build racecondition

### DIFF
--- a/src/tasks/build.js
+++ b/src/tasks/build.js
@@ -100,7 +100,7 @@ const build = options => {
   )
 
   gulp.task('build', () =>
-    runSequence('build-clean', ['build-main', 'build-css'])
+    runSequence('build-clean', 'build-main', 'build-css')
   )
 }
 


### PR DESCRIPTION
trying to run elm-css and node-elm-compiler at the same time was causing a double elm-package install, which caused a existing directory race condition. just sequence them for now instead of running in parallel