### PR TITLE
Dev no main option

### DIFF
--- a/bin/cmds/build.js
+++ b/bin/cmds/build.js
@@ -7,9 +7,14 @@ module.exports = {
   command: build.command,
   description: build.description,
   builder: function(yargs) {
-    yargs.options(build.options).config(config).help('help')
+    yargs
+      .options(build.options)
+      .config(config)
+      .help('help')
   },
   handler: function(argv) {
-    require('../../src/tasks').build(argv)
+    require('../../src/tasks')
+      .build(argv)
+      .catch(e => {})
   },
 }

--- a/bin/cmds/dev.js
+++ b/bin/cmds/dev.js
@@ -14,9 +14,8 @@ module.exports = {
     if (typeof argv.proxy === 'string') {
       argv.proxy = [argv.proxy]
     }
-
     require('../../src/tasks')
       .dev(argv)
-      .catch(() => {})
+      .catch(e => {})
   },
 }

--- a/bin/cmds/init.js
+++ b/bin/cmds/init.js
@@ -13,6 +13,6 @@ module.exports = {
   handler: function(argv) {
     require('../../src/tasks')
       .init(argv)
-      .catch(() => {})
+      .catch(e => {})
   },
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "husky": "^0.14.3",
     "lint-staged": "^4.0.4",
     "mocha": "^3.5.0",
+    "mute": "^2.0.6",
     "nyc": "^11.1.0",
     "portscanner": "^2.1.1",
     "request-promise-native": "^1.0.4",

--- a/src/cmds/dev.js
+++ b/src/cmds/dev.js
@@ -5,11 +5,6 @@ module.exports = {
   command: 'dev [options]',
   description: 'starts elm-factory in dev mode',
   options: {
-    m: {
-      alias: 'main',
-      description: 'main entry file',
-      default: defaults.main,
-    },
     s: {
       alias: 'stylesheets',
       description: 'stylesheets entry file',

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -13,7 +13,6 @@ const build = {
 }
 
 const dev = {
-  main,
   stylesheets,
   html,
   host,

--- a/src/tasks/utils.js
+++ b/src/tasks/utils.js
@@ -45,26 +45,27 @@ const installPackages = (cwd = process.cwd()) => {
   })
 }
 
-const initializeSpinner = () => {
-  const spinner = ora()
-  const space = () => spinner.stopAndPersist({ symbol: spacer(), text: ' ' })
+const initializeSpinner = spinner => {
+  const inner = spinner || ora()
 
   return {
-    space,
+    inner,
+    space: () => inner.stopAndPersist({ symbol: spacer(), text: ' ' }),
     next: text => {
-      space()
-      spinner.text = text
-      spinner.start()
+      inner.stopAndPersist({ symbol: spacer(), text: ' ' })
+      inner.text = text
+      inner.start()
     },
     succeed: text => {
-      spinner.succeed(text)
+      inner.succeed(text)
     },
     fail: (e, rethrow = true) => {
-      spinner.fail((e.message || e).trim())
+      inner.fail((e.message || e).trim())
       if (rethrow) {
         throw e
       }
     },
+    stopAndPersist: opts => spinner.stopAndPersist(opts),
   }
 }
 

--- a/src/tasks/utils.js
+++ b/src/tasks/utils.js
@@ -1,6 +1,10 @@
 const chalk = require('chalk')
 const check = require('check-types')
 const execa = require('execa')
+const fs = require('fs')
+const ora = require('ora')
+
+const spacer = (count = 50) => '-'.repeat(count)
 
 const invalidParam = (type, name) =>
   `parameter \`${name}\` expected \`${type}\``
@@ -11,7 +15,19 @@ const validateParam = (type, name, value, required = true) => {
   return checker[type](value, invalidParam(type, name))
 }
 
-const spacer = (count = 50) => '-'.repeat(count)
+const exists = path => {
+  validateParam('string', 'path', path)
+
+  return new Promise((resolve, reject) => {
+    fs.stat(path, (err, contents) => {
+      if (err) {
+        reject(`could not find ${path}`)
+      } else {
+        resolve(contents)
+      }
+    })
+  })
+}
 
 const installPackages = (cwd = process.cwd()) => {
   validateParam('string', 'cwd', cwd)
@@ -29,9 +45,34 @@ const installPackages = (cwd = process.cwd()) => {
   })
 }
 
+const initializeSpinner = () => {
+  const spinner = ora()
+  const space = () => spinner.stopAndPersist({ symbol: spacer(), text: ' ' })
+
+  return {
+    space,
+    next: text => {
+      space()
+      spinner.text = text
+      spinner.start()
+    },
+    succeed: text => {
+      spinner.succeed(text)
+    },
+    fail: (e, rethrow = true) => {
+      spinner.fail((e.message || e).trim())
+      if (rethrow) {
+        throw e
+      }
+    },
+  }
+}
+
 module.exports = {
   invalidParam,
   validateParam,
   spacer,
+  exists,
   installPackages,
+  initializeSpinner,
 }

--- a/test/cmds/dev-test.js
+++ b/test/cmds/dev-test.js
@@ -6,11 +6,6 @@ import { dev } from '../../src/cmds'
 describe('$ elm-factory dev', () => {
   it('should expose the correct CLI options', () => {
     expect(dev.options).to.eql({
-      m: {
-        alias: 'main',
-        description: 'main entry file',
-        default: defaults.main,
-      },
       s: {
         alias: 'stylesheets',
         description: 'stylesheets entry file',
@@ -48,8 +43,8 @@ describe('$ elm-factory dev', () => {
       },
       'proxy-rewrite': {
         description: 'rewrite proxy paths',
-        default: defaults.proxyRewrite
-      }
+        default: defaults.proxyRewrite,
+      },
     })
   })
 })

--- a/test/defaults-test.js
+++ b/test/defaults-test.js
@@ -15,7 +15,6 @@ describe('defaults', () => {
 
   it('should have the correct dev defaults', () => {
     expect(dev).to.eql({
-      main: './src/Main.elm',
       stylesheets: './src/Stylesheets.elm',
       html: './index.ejs',
       host: '127.0.0.1',

--- a/test/tasks/dev-test.js
+++ b/test/tasks/dev-test.js
@@ -3,6 +3,7 @@ import chaifs from 'chai-fs'
 import chaiAsPromised from 'chai-as-promised'
 import fs from 'fs'
 import http from 'http'
+import mute from 'mute'
 import path from 'path'
 import portscanner from 'portscanner'
 import request from 'request-promise-native'
@@ -57,7 +58,7 @@ const assertIncludes = (str = '', response = '') =>
     `response is missing string '${str}'`
   )
 
-describe.only('DEV TASK', function() {
+describe('DEV TASK', function() {
   before(done => {
     init({ dir, force: true }).then(() => {
       process.chdir(dir)
@@ -381,23 +382,18 @@ describe.only('DEV TASK', function() {
         .rejected
     })
     it('resolves on valid entry', () => {
-      return expect(createWatcher(fn, fn, fn, bs, defaults.main))
-        .to.eventually.be.an('object')
-        .with.property('close')
-    })
-    it('resolves on valid entry', () => {
       return expect(createWatcher(fn, fn, fn, bs, defaults.stylesheets))
         .to.eventually.be.an('object')
         .with.property('close')
     })
     it('bs.watch is called', done => {
-      createWatcher(fn, fn, fn, bs, defaults.main).then(() => {
+      createWatcher(fn, fn, fn, bs, defaults.stylesheets).then(() => {
         expect(spyWatch.called).to.eql(true)
         done()
       })
     })
     it('watcher.on is called', done => {
-      createWatcher(fn, fn, fn, bs, defaults.main).then(() => {
+      createWatcher(fn, fn, fn, bs, defaults.stylesheets).then(() => {
         expect(spyOn.called).to.eql(true)
         done()
       })
@@ -406,11 +402,9 @@ describe.only('DEV TASK', function() {
 
   describe('dev', () => {
     let promise
-
     before(() => {
       promise = dev(defaults)
     })
-
     it('fails', () => {
       return expect(dev({ reactorPort: 'string' })).to.eventually.be.rejected
     })

--- a/test/tasks/dev-test.js
+++ b/test/tasks/dev-test.js
@@ -17,7 +17,6 @@ import {
   startReactor,
   startBrowserSync,
   createWatcher,
-  watch,
   dev,
 } from '../../src/tasks/dev'
 import { invalidParam } from '../../src/tasks/utils'
@@ -58,7 +57,7 @@ const assertIncludes = (str = '', response = '') =>
     `response is missing string '${str}'`
   )
 
-describe('DEV TASK', function() {
+describe.only('DEV TASK', function() {
   before(done => {
     init({ dir, force: true }).then(() => {
       process.chdir(dir)
@@ -350,7 +349,8 @@ describe('DEV TASK', function() {
     })
   })
 
-  describe('watch mode', () => {
+  describe('createWatcher', () => {
+    const fn = () => {}
     let bs
     let spyWatch
     let spyOn
@@ -363,72 +363,43 @@ describe('DEV TASK', function() {
       bs = { watch: spyWatch }
     })
 
-    describe('createWatcher', () => {
-      const fn = () => {}
-
-      describe('params', () => {
-        checkParam('function', 'onChange', createWatcher)([' '])
-        checkParam('function', 'onDeps', createWatcher)([fn, ' '])
-        checkParam('function', 'filter', createWatcher)([fn, fn, ' '])
-        checkParam('object', 'bs', createWatcher)([fn, fn, fn, ' '])
-        checkParam('string', 'entry', createWatcher)([fn, fn, fn, {}, 1])
-      })
-
-      it('returns a promise', () => {
-        expect(createWatcher(fn, fn, fn, bs, ' ').catch(() => {})).to.be.a(
-          'promise'
-        )
-      })
-      it('fails on bad entry', () => {
-        return expect(createWatcher(fn, fn, fn, bs, ' ')).to.eventually.be
-          .rejected
-      })
-      it('resolves on valid entry', () => {
-        return expect(createWatcher(fn, fn, fn, bs, defaults.main))
-          .to.eventually.be.an('object')
-          .with.property('close')
-      })
-      it('resolves on valid entry', () => {
-        return expect(createWatcher(fn, fn, fn, bs, defaults.stylesheets))
-          .to.eventually.be.an('object')
-          .with.property('close')
-      })
-      it('bs.watch is called', done => {
-        createWatcher(fn, fn, fn, bs, defaults.main).then(() => {
-          expect(spyWatch.called).to.eql(true)
-          done()
-        })
-      })
-      it('watcher.on is called', done => {
-        createWatcher(fn, fn, fn, bs, defaults.main).then(() => {
-          expect(spyOn.called).to.eql(true)
-          done()
-        })
-      })
+    describe('params', () => {
+      checkParam('function', 'onChange', createWatcher)([' '])
+      checkParam('function', 'onDeps', createWatcher)([fn, ' '])
+      checkParam('function', 'filter', createWatcher)([fn, fn, ' '])
+      checkParam('object', 'bs', createWatcher)([fn, fn, fn, ' '])
+      checkParam('string', 'entry', createWatcher)([fn, fn, fn, {}, 1])
     })
 
-    describe('watch', () => {
-      describe('params', () => {
-        checkParam('object', 'bs', watch)([' '])
-        checkParam('string', 'main', watch)([{}, 1])
-        checkParam('string', 'stylesheets', watch)([{}, ' ', 1])
-        checkParam('string', 'dir', watch)([{}, ' ', ' ', 1])
+    it('returns a promise', () => {
+      expect(createWatcher(fn, fn, fn, bs, ' ').catch(() => {})).to.be.a(
+        'promise'
+      )
+    })
+    it('fails on bad entry', () => {
+      return expect(createWatcher(fn, fn, fn, bs, ' ')).to.eventually.be
+        .rejected
+    })
+    it('resolves on valid entry', () => {
+      return expect(createWatcher(fn, fn, fn, bs, defaults.main))
+        .to.eventually.be.an('object')
+        .with.property('close')
+    })
+    it('resolves on valid entry', () => {
+      return expect(createWatcher(fn, fn, fn, bs, defaults.stylesheets))
+        .to.eventually.be.an('object')
+        .with.property('close')
+    })
+    it('bs.watch is called', done => {
+      createWatcher(fn, fn, fn, bs, defaults.main).then(() => {
+        expect(spyWatch.called).to.eql(true)
+        done()
       })
-
-      it('returns a promise', () => {
-        expect(watch({}, ' ', ' ', ' ').catch(() => {})).to.be.a('promise')
-      })
-      it('rejects invalid entry paths', () => {
-        return expect(watch({}, ' ', ' ', ' ')).to.eventually.be.rejected
-      })
-      it('resolves valid entry paths with two watchers', () => {
-        const promise = watch(bs, defaults.main, defaults.stylesheets, ' ')
-
-        return Promise.all([
-          promise.should.eventually.be.fulfilled,
-          promise.should.eventually.have.a.nested.property('[0].close'),
-          promise.should.eventually.have.a.nested.property('[1].close'),
-        ])
+    })
+    it('watcher.on is called', done => {
+      createWatcher(fn, fn, fn, bs, defaults.main).then(() => {
+        expect(spyOn.called).to.eql(true)
+        done()
       })
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3726,6 +3726,10 @@ mustache@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.0.tgz#4028f7778b17708a489930a6e52ac3bca0da41d0"
 
+mute@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/mute/-/mute-2.0.6.tgz#8bf10f1f285ea38c9db2630bff675c114c973ed5"
+
 nan@^2.3.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"


### PR DESCRIPTION
Rather than demanding upfront configuration for watching file trees, we should allow the user to browse around to different `*.elm` files and get watching capabilities.

This adds on-demand watching.

Also improves some ora feedback